### PR TITLE
fix: correct input/output name retrieval in run_inference method

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -39,8 +39,8 @@ impl ModelManager {
         let input_tensor = Value::from_array((shape.as_slice(), data))?;
 
         // Get input/output names before running inference (to avoid borrow issues)
-        let input_name = self.session.inputs[0].name.clone();
-        let output_name = self.session.outputs[0].name.clone();
+        let input_name = {String::from(self.session.inputs()[0].name())};
+        let output_name = {String::from(self.session.outputs()[0].name())};
 
         // Run inference
         let outputs = self.session.run(ort::inputs![input_name.as_str() => input_tensor])?;


### PR DESCRIPTION
The current commit produced the following error on build:

error[E0616]: field `inputs` of struct `Session` is private
  --> src/manager.rs:42:39
   |
42 |         let input_name = self.session.inputs[0].name.clone();
   |                                       ^^^^^^ private field

Then when calling inputs() and name(), it resulted in borrow issues. The crate now builds with this fix.